### PR TITLE
Feat/split fd set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ CXXFLAGS = -Wall -Werror -Wextra -std=c++98 -pedantic -g -fsanitize=address
 
 INCLUDE_DIR = includes
 INCLUDE =	ft_irc.hpp \
+			Utility.hpp \
 			Server.hpp \
 			Channel.hpp \
 			Client.hpp \
@@ -15,6 +16,7 @@ INCLUDE =	ft_irc.hpp \
 
 SRC_DIR = srcs
 SRC	=		main.cpp \
+			Utility.cpp \
 			Server.cpp \
 			Channel.cpp \
 			Client.cpp \

--- a/includes/Channel.hpp
+++ b/includes/Channel.hpp
@@ -19,8 +19,14 @@ class Channel {
   void join(Client *client, const std::string &key);
   void part(Client *client, const std::string &message);
   void quit(Client *client);
+  // void boradcast(Client *client, const std::string &message);
+  void privmsg(Client *client, const std::string &message);
+
+  // op methods
   void op_client(Client *client, Client *target);
   void deop_client(Client *client, Client *target);
+  void set_key(Client *client, const std::string &key);
+  void set_topic(Client *client, const std::string &topic);
 
   // manage client
   bool is_client_in_channel(Client *client) const;
@@ -49,7 +55,8 @@ class Channel {
   void set_key(const std::string &key);
 
   // manage max clients
-  bool is_channel_full() const;
+  bool full() const;
+  bool empty() const;
   std::size_t get_max_clients() const;
   void set_max_clients(std::size_t max_clients);
 

--- a/includes/Client.hpp
+++ b/includes/Client.hpp
@@ -49,6 +49,9 @@ class Client {
   ~Client();
 
   // join, part channel
+  void nick(const std::string &nickname);
+  void user(const std::string &username, const std::string &hostname,
+            const std::string &servername, const std::string &realname);
   void join_channel(Channel *channel);
   void part_channel(Channel *channel);
 
@@ -63,14 +66,6 @@ class Client {
   const std::string &get_servername() const;
   const std::string &get_realname() const;
   int get_fd() const;
-  // std::vector<Channel *> &get_channels();
-  // Channel *is_channel_operator(const std::string &channel_name);
-
-  void set_nickname(const std::string &nickname);
-  void set_username(const std::string &username);
-  void set_hostname(const std::string &hostname);
-  void set_servername(const std::string &servername);
-  void set_realname(const std::string &realname);
 
   // status bitset
   bool is_cap_negotiated() const;

--- a/includes/NumericReply.hpp
+++ b/includes/NumericReply.hpp
@@ -51,6 +51,14 @@
   ("433 " + (client).get_nickname() + " " + (nickname) + \
    " :Nickname is already in use\r\n")
 
+// define QUIT_REPLIES
+#define RPL_QUIT(client, message) \
+  (":" + CLIENT_SOURCE((client)) + " QUIT :" + (message) + "\r\n")
+
+// define ERROR_REPLIES
+#define RPL_ERROR(client, message) \
+  (":" + CLIENT_SOURCE((client)) + " ERROR :" + (message) + "\r\n")
+
 // define JOIN_REPLIES
 #define RPL_BRDCAST_JOIN(client, channel) \
   (":" + CLIENT_SOURCE((client)) + " JOIN " + (channel).get_name() + "\r\n")
@@ -62,6 +70,12 @@
    " :End of /NAMES list\r\n")
 #define RPL_DEFAULTCHANMODE(client, channel) \
   ("324 " + (client).get_nickname() + " " + (channel).get_name() + " +\r\n")
+#define ERR_USERNOTINCHANNEL_441(client, target, channel)                   \
+  ("441 " + (client).get_nickname() + " " + (target).get_nickname() + " " + \
+   (channel).get_name() + " :They aren't on that channel\r\n")
+#define ERR_USERONCHANNEL_443(client, target, channel)                      \
+  ("443 " + (client).get_nickname() + " " + (target).get_nickname() + " " + \
+   (channel).get_name() + " :is already on channel\r\n")
 #define ERR_NOTONCHANNEL_442(client, channel)                      \
   ("442 " + (client).get_nickname() + " " + (channel).get_name() + \
    " :You're not on that channel\r\n")
@@ -74,23 +88,39 @@
 #define ERR_BADCHANNELKEY_475(client, channel)                     \
   ("475 " + (client).get_nickname() + " " + (channel).get_name() + \
    " :Cannot join channel (+k)\r\n")
+#define ERR_CHANOPRIVSNEEDED_482(client, channel)                  \
+  ("482 " + (client).get_nickname() + " " + (channel).get_name() + \
+   " :You're not channel operator\r\n")
 
 // define PART_REPLIES
 #define RPL_BRDCAST_PART(client, channel, message)                          \
   (":" + CLIENT_SOURCE((client)) + " PART " + (channel).get_name() + " :" + \
    (message) + "\r\n")
+#define ERR_NOSUCHCHANNEL_403(client, param) \
+  ("403 " + (client).get_nickname() + " " + (param) + " :No such channel\r\n")
 
 // define PING_REPLIES
 #define RPL_PONG(client, params) ("PONG :" + params + "\r\n")
 
 // define MODE_REPLIES
+#define RPL_BRDCAST_MODE(client, channel, mode, params)                    \
+  (":" + CLIENT_SOURCE((client)) + " MODE " + (channel).get_name() + " " + \
+   (mode) + " " + (params) + "\r\n")
 #define ERR_BADCHANMASK_476(client, channel)            \
   ("476 " + (client).get_nickname() + " " + (channel) + \
    " :Bad Channel Mask\r\n")
 #define ERR_UMODEUNKNOWNFLAG_501(client) \
   ("501 " + (client).get_nickname() + " :Unknown mode flag\r\n")
 
+// define PRIVMSG_REPLIES
+#define RPL_PRIVMSG(client, target, message)                                   \
+  (":" + CLIENT_SOURCE((client)) + " PRIVMSG " + (target) + " :" + (message) + \
+   "\r\n")
+
 // define ERR_REPLIES
+#define ERR_NOSUCHNICK_401(client, target)             \
+  ("401 " + (client).get_nickname() + " " + (target) + \
+   " :No such nick/channel\r\n")
 #define ERR_INPUTTOOLONG_417(client) \
   ("417 " + (client).get_nickname() + " :Input line was too long\r\n")
 #define ERR_UNKNOWNCOMMAND_421(client, command)           \

--- a/includes/Utility.hpp
+++ b/includes/Utility.hpp
@@ -1,0 +1,15 @@
+#pragma once
+#ifndef UTILITY_HPP
+#define UTILITY_HPP
+
+class Client;
+
+struct DerefLess {
+  template <class Ptr>
+  bool operator()(Ptr const &p1, Ptr const &p2) const {
+    return *p1 < *p2;
+  }
+  bool operator()(const Client *p1, const int i) const;
+};
+
+#endif

--- a/srcs/Client.cpp
+++ b/srcs/Client.cpp
@@ -48,6 +48,20 @@ void Client::part_channel(Channel *channel) {
   }
 }
 
+void Client::nick(const std::string &nickname) {
+  _nickname = nickname;
+  _status.set(NICK_SET, true);
+}
+
+void Client::user(const std::string &username, const std::string &hostname,
+                  const std::string &servername, const std::string &realname) {
+  _username = username;
+  _hostname = hostname;
+  _servername = servername;
+  _realname = realname;
+  _status.set(USER_SET, true);
+}
+
 void Client::recv() { _stream.recv(); }
 void Client::send() { _stream.send(); }
 
@@ -57,14 +71,6 @@ const std::string &Client::get_hostname() const { return _hostname; }
 const std::string &Client::get_servername() const { return _servername; }
 const std::string &Client::get_realname() const { return _realname; }
 int Client::get_fd() const { return _stream.get_fd(); }
-
-void Client::set_nickname(const std::string &nickname) { _nickname = nickname; }
-void Client::set_username(const std::string &username) { _username = username; }
-void Client::set_hostname(const std::string &hostname) { _hostname = hostname; }
-void Client::set_servername(const std::string &servername) {
-  _servername = servername;
-}
-void Client::set_realname(const std::string &realname) { _realname = realname; }
 
 bool Client::is_cap_negotiated() const { return _status.test(CAP_NEGOTIATED); }
 bool Client::is_in_negotiation() const { return _status.test(IN_NEGOTIATION); }

--- a/srcs/Utility.cpp
+++ b/srcs/Utility.cpp
@@ -1,0 +1,7 @@
+#include "Utility.hpp"
+
+#include "Client.hpp"
+
+bool DerefLess::operator()(const Client *p1, const int i) const {
+  return p1->get_fd() < i;
+}

--- a/srcs/main.cpp
+++ b/srcs/main.cpp
@@ -4,7 +4,6 @@
 #include <netinet/in.h>
 #include <poll.h>
 #include <signal.h>
-#include <string>
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -14,27 +13,23 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <string>
 
 #include "Server.hpp"
 #include "ft_irc.hpp"
 
-int main(int argc, char **argv)
-{
-	(void)argc;
-	if (argc != 3)
-	{
-		std::cerr << "Usage: " << argv[0] << " <port> <password>" << std::endl;
-		return 1;
-	}
-	try
-	{
-		Server server(atoi(argv[1]), std::string(argv[2]));
-		server.run();
-	}
-	catch (std::exception &e)
-	{
-		std::cerr << "Error: " << e.what() << std::endl;
-	}
+int main(int argc, char **argv) {
+  (void)argc;
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <port> <password>" << std::endl;
+    return 1;
+  }
+  try {
+    Server server(atoi(argv[1]), std::string(argv[2]));
+    server.run();
+  } catch (std::exception &e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+  }
 
-	return 0;
+  return 0;
 }


### PR DESCRIPTION
nc로도 테스트 가능하도록 파싱 일부 수정
클라이언트 setter 일부 제거하고 메소드 사용하도록 수정 close #36 
채널 관리 수정
client를 std::map<int, Client *>로 관리하도록 수정
QUIT 처리를 위해 연결종료 즉시 삭제가 아니라 나중에 삭제하도록 수정
실시간 버퍼 처리를 위해 read_fd write_fd 처리 분리 close #41 
PART 통합 close #35 
QUIT 구현 close #40 
PRIVMSG 구현 close #39 
